### PR TITLE
feat: Integrate flowchart UML into chat messages

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -26,8 +26,8 @@ export async function POST(request: Request): Promise<NextResponse> {
     }
 
     // Prepare the message for Lyzr AI
-    const fullMessage = uml 
-      ? `Here's my UML diagram:\n\n${uml}\n\nAnd here's my question: ${message}`
+    const fullMessage = uml
+      ? `${message}\n\nUML:\n${uml}`
       : message;
 
     // Call Lyzr AI API

--- a/src/components/Flow.tsx
+++ b/src/components/Flow.tsx
@@ -131,4 +131,22 @@ export function Flow() {
       </ReactFlow>
     </div>
   );
-} 
+}
+
+export const generateUmlFromFlow = (nodes: Node[], edges: Edge[]): string => {
+  let umlString = "Nodes:\n";
+  nodes.forEach(node => {
+    umlString += `- ${node.data.label} (Type: ${node.data.type})\n`;
+  });
+
+  umlString += "\nEdges:\n";
+  edges.forEach(edge => {
+    const sourceNode = nodes.find(node => node.id === edge.source);
+    const targetNode = nodes.find(node => node.id === edge.target);
+    if (sourceNode && targetNode) {
+      umlString += `- ${sourceNode.data.label} -> ${targetNode.data.label}\n`;
+    }
+  });
+
+  return umlString;
+};


### PR DESCRIPTION
This feature enables the conversion of flowcharts into a textual UML format, saves this UML, and includes it in messages sent via the chat interface.

Key changes:

1.  **Flowchart to UML Conversion:**
    - I added `generateUmlFromFlow(nodes, edges)` in `src/components/Flow.tsx` to convert ReactFlow data into a textual UML string (listing nodes, their types, and connections).

2.  **Save UML and Navigate:**
    - I added a "Go to Chat" button to `src/components/Toolbar.tsx`.
    - When clicked, this button generates the UML from the current flowchart, sends it to the `/api/save-uml` endpoint to be stored in MongoDB, and then navigates you to the `/chat` page.

3.  **Chat Message Formatting:**
    - I modified `src/app/api/chat/route.ts` to change the format of messages sent to the Lyzr AI. Your text message now precedes the UML diagram, formatted as: `<your_message>

UML:
<uml_diagram_string>`
    - If no UML is present, only your message is sent.

4.  **UML Persistence in Chat:**
    - `src/app/chat/page.tsx` already had logic to fetch the latest UML diagram from `/api/get-latest-uml` upon loading. This ensures that once a flowchart's UML is saved, it's available in the chat, persisting across chat page refreshes until a new flowchart is saved.

This addresses the issue of embedding flowchart UML into chat messages and persisting it until a page refresh (achieved by saving to DB and reloading).